### PR TITLE
fix: update search placeholder

### DIFF
--- a/src/components/IconGrid/IconGrid.vue
+++ b/src/components/IconGrid/IconGrid.vue
@@ -176,7 +176,7 @@ const filteredItems = computed(() => {
         <div class="icongrid-search-icon">
           <SearchIcon />
         </div>
-        <input v-model="filterText" class="icongrid-search-input" :placeholder="`Search ${filteredItems.length} operators`" />
+        <input v-model="filterText" class="icongrid-search-input" :placeholder="`Search ${filteredItems.length} operator icons`" />
         <Transition name="slide-fade-left">
           <button v-if="filterText" class="icongrid-search-clear" @click="clearFilters('text')">
             <CloseIcon />


### PR DESCRIPTION
Current placeholder is a bit misleading, there isn't 76 operators but 73 instead. Because of 5 different recruit icons.